### PR TITLE
Convert strings to URL Slugs #209

### DIFF
--- a/development/string_to_url_slug/README.md
+++ b/development/string_to_url_slug/README.md
@@ -1,0 +1,8 @@
+# String to url
+## Description
+Many content management sites (CMS) have the titles of a post added to part of the URL for simple bookmarking purposes. For example, if you write a Medium post titled "How to use Github", it's likely the URL would have some form of the title string in it (".../how-to-use-github").
+
+Write a function in Javascript such that it converts a string ``title`` and returns the hyphenated version for the URL.
+
+## How to
+Include ``string_to_url_slug.js`` in your html page and use the ``string_to_url_slug(title)`` javascript function to get the hyphenated version of the title, an example is provided in the ``example.html`` file

--- a/development/string_to_url_slug/example.html
+++ b/development/string_to_url_slug/example.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>String to url slug example</title>
+  <script src="./string_to_url_slug.js"></script>
+  <script>
+    function test() {
+
+      testArray = [
+        "How to use Github",
+        "Why are some apples green?",
+        "How to order a pizza",
+        "àáäâãåèéëêìíïîòóöôùúüûñçßÿœæŕśńṕẃǵǹḿǘẍźḧŠŽšžŸÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝ",
+        "Tom & Jerry"
+      ];
+
+      testArray.forEach((element) => {
+        let table = document.getElementById("example");
+        let tr = document.createElement("tr");
+        let tdStrInput = document.createElement("td");
+        let tdUrlSlugOutput = document.createElement("td");
+        let strInput = document.createTextNode(element);
+        let urlSlugOutput = document.createTextNode(string_to_url_slug(element));
+
+        tdStrInput.appendChild(strInput);
+        tdUrlSlugOutput.appendChild(urlSlugOutput);
+        tr.appendChild(tdStrInput);
+        tr.appendChild(tdUrlSlugOutput);
+        table.appendChild(tr);
+      });
+    }
+  </script>
+</head>
+
+<body onload="test();">
+  <table id="example">
+    <tr>
+      <th>Input string</th>
+      <th>Output url slug</th>
+    </tr>
+  </table>
+</body>
+
+</html>

--- a/development/string_to_url_slug/string_to_url_slug.js
+++ b/development/string_to_url_slug/string_to_url_slug.js
@@ -1,0 +1,33 @@
+function string_to_url_slug(title)
+{
+  //First step: replace uppercase letters with lowercase + accents like "éèàüöä" with "eeauoa" + replace "&" with "and" WITHOUT USING .replace
+  let inStringArray = title.split("");
+  let outStringArray = [];
+  let inSpecialCharArray = "àáäâãåèéëêìíïîòóöôùúüûñçßÿœæŕśńṕẃǵǹḿǘẍźḧŠŽšžŸÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝ".split("");
+  let outSpecialCharArray = "aaaaaaeeeeiiiioooouuuuncsyoarsnpwgnmuxzhSZszYAAAAAACEEEEIIIIDNOOOOOUUUUY".split("");
+
+  inStringArray.forEach((c) =>
+  {
+    if (inSpecialCharArray.includes(c))
+    {
+      outStringArray.push(outSpecialCharArray[inSpecialCharArray.indexOf(c)]);
+    }
+    else if (c == "&")
+    {
+      outStringArray.push("and")
+    }
+    else
+    {
+      outStringArray.push(c.toLowerCase());
+    }
+  });
+
+  //Second step: filter all non alphanumeric characters and replace blank spaces with "-"
+  let url_slug = outStringArray.filter((c) =>
+  {
+    let pattern = RegExp("\\w|\\s");
+    return pattern.test(c);
+  }).join("").split(" ").join("-");
+
+  return url_slug;
+}


### PR DESCRIPTION
Resolves Issue #209
### Description
The function  replaces uppercase letters with lowercase + accents like "éèàüöä" with "eeauoa" + replace "&" with "and" + filters all non alphanumeric characters and replaces blank spaces with "-"

### How to run
Include ``string_to_url_slug.js`` in your html page and use the ``string_to_url_slug(title)`` javascript function to get the hyphenated version of the title, an example is provided in the ``example.html`` file

### Checklist
- [x] Code compiles correctly.
- [x] Changes are tested properly.
- [x] Added the README / documentation, if necessary.
- [x] Followed the Contributing guidelines.
- [x] Resolved merge conflicts, if any.

