### PR TITLE
Implemented one time pad

### DIFF
--- a/systems/cryptography/one-time-pad/C/main.c
+++ b/systems/cryptography/one-time-pad/C/main.c
@@ -1,0 +1,71 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <string.h>
+
+#define NDEBUG
+
+const size_t LINE_LENGTH = 1024;
+const char ALPHABET_LENGTH = 26;
+
+bool validate (char * string) {
+    for (; *string != '\0' && *string != '\n'; string++) {
+        char c = *string;
+        if (c < 'a' || c > 'z') {
+            return false;
+        }
+    }
+
+    if (*string == '\0') {
+        return false;
+    }
+    return true;
+}
+
+void encrypt (char * string, char * key) {
+    assert (strlen (key) >= strlen (string));
+    assert (validate(key));
+    assert (validate(string));
+
+    for (; *string != '\n'; string++, key++) {
+        char index = (*string - 'a') + (*key - 'a');
+        *string = index % ALPHABET_LENGTH + 'a';
+    }
+}
+
+void decrypt (char * string, char * key) {
+    assert (strlen (key) >= strlen (string));
+    assert (validate(key));
+    assert (validate(string));
+
+    for (; *string != '\n'; string++, key++) {
+        char index = (*string - 'a') + (ALPHABET_LENGTH - (*key - 'a'));
+        *string = index % ALPHABET_LENGTH + 'a';
+    }
+}
+
+int main (void) {
+    char string[LINE_LENGTH];
+    char key[LINE_LENGTH];
+
+    fgets (string, LINE_LENGTH - 1, stdin);
+    fgets (key, LINE_LENGTH - 1, stdin);
+
+    if (!validate(key) || !validate(string)) {
+        fprintf (stderr, "Key and string must only contain lowercase letters, and end with a newline.\n");
+        return 1;
+    }
+
+    if (strlen (key) < strlen(string)) {
+        fprintf (stderr, "Key must be at least as long as the string to be encoded\n");
+        return 1;
+    }
+
+    encrypt (string, key);
+    printf ("%s", string);
+
+    /* decrypt (string, key); */
+    /* printf ("%s", string); */
+
+    return 0;
+}


### PR DESCRIPTION
Resolves Issue #217

### Description
This program accepts two lines of input from `stdin`. The first line contains the string to be encrypted, the second line contains the one time pad key. The result of encrypting the string with the key will be printed to `stdout`.

This program consists of three functions, `validate`, `encrypt`, and `decrypt`.

As per the brief, this program should accept two strings, both of which contain only lowercase letters. the `validate` function ensures that this is the case.

`encrypt` and `decrypt` take two arguments, the string to be encrypted/decrypted, and the one time pad. The string is encrypted or decrypted in place. We assert that the key and the string are valid according to `validate`, in addition, we assert that the key is at least as long as the string to be encrypted.

### Screenshots (if required)

``` bash
$ ./a.out
quizzingisfun
tequilamockingbird
jyythtnswupca
$ ./a.out
hello
goodbye
nszop
$ ./a.out
hello
xmckl
eqnvz
$ ./a.out
aoehaufhaeiufhafiuhefiuhewfieauhfliuaewfheakljfhaewjklfhawelfaew
awecuauncauecaeanekcajenckauaekuwcnaweucnewiucnalwnicuaewclnaecunelc
akijuuzucecyhhefvyrgfryuggfceeebbnvuwiqhuiwsflshlajrmfflwypyfegq
$ ./a.out
abcdefghijklmnopqrstuvwxyz
ueacnileuncawlicnaeilucniewuicn
ufcfrnrlcwmliywrdrwbfpykgd
```

### How to run

``` bash
cc main.c && ./a.out
```